### PR TITLE
Specify requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,4 +4,5 @@ setup(
     name='harvest',
     version='1.0',
     py_modules=['harvest'],
+    requires=['python-dateutil'],
 )


### PR DESCRIPTION
State in the setup that the package requires python-dateutil so that pip (or easy_install) will fetch it as well.
