### PR TITLE
Fix a quoted string

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Example:
 	h = Harvest( 'https://foo.harvestapp.com', 'foo@bar.com', 'mypassword' )
 	user = h.find_user( 'John', 'Doe' )
 	if user:
-		print "The user ID = %d' % user.id
+		print 'The user ID = %d' % user.id
 
 		start = datetime.today()
 		end = start + timedelta(7)


### PR DESCRIPTION
This fixes the example code - the string had mis-matching quotes.
