### PR TITLE
Treat entries of type 'dateTime' as datetime

### DIFF
--- a/harvest.py
+++ b/harvest.py
@@ -278,7 +278,7 @@ class Harvest(object):
                         return int( text )
                     except ValueError:
                         return 0
-                elif entry_type in ('date','datetime'):
+                elif entry_type in ('date','datetime','dateTime'):
                     return parseDate( text )
                 elif entry_type == 'boolean':
                     try:


### PR DESCRIPTION
Harvest have changed the type of date/time entries from 'datetime' to 'dateTime', thus breaking any scripts using this API library.
