### PR TITLE
changed requires to install_requires to accomodate setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,5 @@ setup(
     name='harvest',
     version='1.0',
     py_modules=['harvest'],
-    requires=['python-dateutil'],
+    install_requires=['python-dateutil'],
 )


### PR DESCRIPTION
installing with pip currently throws an error, which this fixes.